### PR TITLE
fixes navbar sub menu items opening behind badge

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -236,7 +236,7 @@ function MobileNav() {
 
 export function Navbar({ banner }: { banner?: React.ReactNode }) {
   return (
-    <Disclosure as="header" className="pt-8">
+    <Disclosure as="header" className="relative z-30 pt-8">
       <div>
         <div className="relative flex justify-between">
           <div className="relative flex gap-6">


### PR DESCRIPTION
- fixes #143


The badge bar uses `backdrop-blur-xl` which creates a new stacking context, and the navbar header has no z-index, so the dropdown's `z-10` only applies within the navbar's local context. 

<img width="1764" height="1283" alt="image" src="https://github.com/user-attachments/assets/03cd2a1f-c3fe-4e6f-8d04-80a6c2ad00ee" />


https://openhealthcarenetwork.atlassian.net/browse/ENG-434