### PR TITLE
Clarify funding JSON links

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -117,7 +117,7 @@ function Hero() {
               href="/funding.json"
               className="w-full sm:w-auto"
             >
-              View funding.json
+              View raw funding.json
             </Button>
           </div>
         </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -121,7 +121,7 @@ function Sitemap() {
           <SitemapLink href="/press-media">Press & Media</SitemapLink>
           <SitemapLink href="/careers">Careers</SitemapLink>
           <SitemapLink href="/contact">Contact</SitemapLink>
-          <SitemapLink href="/funding.json">Funding.json</SitemapLink>
+          <SitemapLink href="/funding.json">Funding metadata</SitemapLink>
         </SitemapLinks>
       </div>
     </>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -73,7 +73,7 @@ const links = [
       { href: '/blog', label: 'Blog' },
       { href: '/press-media', label: 'Press & Media' },
       { href: '/faq', label: 'FAQ' },
-      { href: '/funding.json', label: 'Funding.json' },
+      { href: '/funding.json', label: 'Funding metadata' },
       { href: '/contact', label: 'Contact' },
     ],
   },


### PR DESCRIPTION
Clarifies visitor-facing links to the funding JSON manifest so users understand it is raw metadata while keeping the endpoint publicly accessible.

Validation:
- npm run lint
- npm run build